### PR TITLE
Implement script to run app

### DIFF
--- a/TENNIS_APP_README.md
+++ b/TENNIS_APP_README.md
@@ -1,0 +1,32 @@
+# Tennis Betting AI Web App
+
+## Setup
+
+1. Copy `backend/.env.example` to `backend/.env` and fill in your API keys for:
+   - `OPENAI_API_KEY`
+   - `RAPIDAPI_KEY`
+   - `THEODDS_API_KEY`
+
+2. Install backend dependencies:
+   ```bash
+   npm install express cors dotenv openai axios
+   ```
+
+3. Start the backend server:
+   ```bash
+   node backend/app.js
+   ```
+
+4. Install frontend dependencies and start the React app:
+   ```bash
+   cd frontend
+   npm install
+   npm start
+   ```
+
+Alternatively, from the repository root you can start both servers at once:
+```bash
+pnpm run start-tennis-app
+```
+
+The frontend runs on port 3000 and the backend on port 5000.

--- a/backend/.env
+++ b/backend/.env
@@ -1,0 +1,3 @@
+OPENAI_API_KEY=your_openai_key_here
+RAPIDAPI_KEY=your_rapidapi_key_here
+THEODDS_API_KEY=your_theodds_key_here

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+OPENAI_API_KEY=your_openai_key_here
+RAPIDAPI_KEY=your_rapidapi_key_here
+THEODDS_API_KEY=your_theodds_key_here

--- a/backend/agents/explainerAgent.js
+++ b/backend/agents/explainerAgent.js
@@ -1,0 +1,14 @@
+const { openai } = require('../services/openaiService');
+
+async function runExplainerAgent(summary, prediction) {
+  const prompt = `Summary:\n${summary}\nPrediction:\n${JSON.stringify(prediction)}\n\nWrite a 2-3 sentence explanation for the betting recommendation.`;
+
+  const completion = await openai.chat.completions.create({
+    messages: [{ role: 'user', content: prompt }],
+    model: 'gpt-3.5-turbo'
+  });
+
+  return completion.choices[0].message.content.trim();
+}
+
+module.exports = { runExplainerAgent };

--- a/backend/agents/matchAnalyst.js
+++ b/backend/agents/matchAnalyst.js
@@ -1,0 +1,14 @@
+const { openai } = require('../services/openaiService');
+
+async function runMatchAnalyst(playerStats, matchContext) {
+  const prompt = `You are a tennis expert. Summarize this matchup in 3-4 sentences using the data:\n\nPlayer 1:\n${playerStats.player1}\n\nPlayer 2:\n${playerStats.player2}\n\nMatch Context:\n${matchContext}`;
+
+  const completion = await openai.chat.completions.create({
+    messages: [{ role: 'user', content: prompt }],
+    model: 'gpt-3.5-turbo'
+  });
+
+  return completion.choices[0].message.content.trim();
+}
+
+module.exports = { runMatchAnalyst };

--- a/backend/agents/predictionAgent.js
+++ b/backend/agents/predictionAgent.js
@@ -1,0 +1,19 @@
+const { openai } = require('../services/openaiService');
+
+async function runPredictionAgent(summary, odds) {
+  const prompt = `Based on this summary:\n${summary}\n\nOdds:\nPlayer 1: ${odds.player1}\nPlayer 2: ${odds.player2}\n\nEstimate win probabilities. Recommend a value bet. Return as JSON:\n{\n  "win_prob_player1": number,\n  "win_prob_player2": number,\n  "value_bet": "string",\n  "confidence_level": "Low | Medium | High"\n}`;
+
+  const completion = await openai.chat.completions.create({
+    messages: [{ role: 'user', content: prompt }],
+    model: 'gpt-3.5-turbo'
+  });
+
+  try {
+    return JSON.parse(completion.choices[0].message.content);
+  } catch (err) {
+    console.error('Error parsing prediction response', err.message);
+    return null;
+  }
+}
+
+module.exports = { runPredictionAgent };

--- a/backend/app.js
+++ b/backend/app.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const cors = require('cors');
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const predictRoute = require('./routes/predict');
+const bestBetsRoute = require('./routes/bestBets');
+
+app.use('/predict', predictRoute);
+app.use('/best-bets', bestBetsRoute);
+
+const PORT = process.env.PORT || 5000;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
+
+module.exports = app;

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "tennis-betting-backend",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "main": "app.js",
+  "dependencies": {
+    "axios": "^1.6.8",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "openai": "^4.27.0"
+  },
+  "scripts": {
+    "start": "node app.js"
+  }
+}

--- a/backend/routes/bestBets.js
+++ b/backend/routes/bestBets.js
@@ -1,0 +1,63 @@
+const express = require('express');
+const router = express.Router();
+
+const { getUpcomingMatches, getMatchStats } = require('../services/apiFootballService');
+const { getMatchOdds } = require('../services/theOddsService');
+const { runMatchAnalyst } = require('../agents/matchAnalyst');
+const { runPredictionAgent } = require('../agents/predictionAgent');
+const { runExplainerAgent } = require('../agents/explainerAgent');
+
+function calcImpliedProb(odd) {
+  return odd ? 1 / odd : null;
+}
+
+router.get('/', async (_req, res) => {
+  try {
+    const matches = await getUpcomingMatches();
+    const results = [];
+
+    for (const m of matches) {
+      try {
+        const player1 = m?.players?.[0]?.name || m?.player1 || m?.teams?.home?.name;
+        const player2 = m?.players?.[1]?.name || m?.player2 || m?.teams?.away?.name;
+        if (!player1 || !player2) continue;
+
+        const stats = await getMatchStats(player1, player2);
+        const oddsData = await getMatchOdds(player1, player2);
+        let odds;
+        if (oddsData && oddsData.bookmakers?.[0]?.markets?.[0]?.outcomes) {
+          const [home, away] = oddsData.bookmakers[0].markets[0].outcomes;
+          odds = { player1: home.price, player2: away.price };
+        }
+
+        const summary = await runMatchAnalyst(
+          { player1: stats?.player1, player2: stats?.player2 },
+          m,
+        );
+        const prediction = await runPredictionAgent(summary, odds);
+        const explanation = await runExplainerAgent(summary, prediction);
+
+        results.push({
+          players: { player1, player2 },
+          summary,
+          prediction,
+          explanation,
+          impliedOdds: {
+            player1: calcImpliedProb(odds?.player1),
+            player2: calcImpliedProb(odds?.player2),
+          },
+        });
+      } catch (loopErr) {
+        console.error('Error processing match', loopErr.message);
+      }
+    }
+
+    results.sort((a, b) => (b.prediction?.confidence || 0) - (a.prediction?.confidence || 0));
+    res.json(results);
+  } catch (err) {
+    console.error('Error handling /best-bets request', err.message);
+    res.status(500).json({ error: 'Failed to fetch best bets' });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/predict.js
+++ b/backend/routes/predict.js
@@ -1,0 +1,58 @@
+const express = require('express');
+const router = express.Router();
+
+const { getMatchStats } = require('../services/apiFootballService');
+const { getMatchOdds } = require('../services/theOddsService');
+const { runMatchAnalyst } = require('../agents/matchAnalyst');
+const { runPredictionAgent } = require('../agents/predictionAgent');
+const { runExplainerAgent } = require('../agents/explainerAgent');
+
+function calcImpliedProb(odd) {
+  return odd ? 1 / odd : null;
+}
+
+router.post('/', async (req, res) => {
+  try {
+    const { player1, player2, matchContext, playerStats, odds } = req.body || {};
+
+    if (!playerStats && (!player1 || !player2)) {
+      return res.status(400).json({ error: 'Player names or stats required' });
+    }
+
+    let stats = playerStats;
+    if (!stats && player1 && player2) {
+      stats = await getMatchStats(player1, player2);
+    }
+
+    let matchOdds = odds;
+    if (!matchOdds && player1 && player2) {
+      const match = await getMatchOdds(player1, player2);
+      if (match && match.bookmakers?.[0]?.markets?.[0]?.outcomes) {
+        const [home, away] = match.bookmakers[0].markets[0].outcomes;
+        matchOdds = {
+          player1: home.price,
+          player2: away.price,
+        };
+      }
+    }
+
+    const summary = await runMatchAnalyst(
+      { player1: stats?.player1, player2: stats?.player2 },
+      matchContext,
+    );
+    const prediction = await runPredictionAgent(summary, matchOdds);
+    const explanation = await runExplainerAgent(summary, prediction);
+
+    const implied = {
+      player1: calcImpliedProb(matchOdds?.player1),
+      player2: calcImpliedProb(matchOdds?.player2),
+    };
+
+    res.json({ summary, prediction, explanation, impliedOdds: implied });
+  } catch (err) {
+    console.error('Error handling /predict request', err.message);
+    res.status(500).json({ error: 'Failed to generate prediction' });
+  }
+});
+
+module.exports = router;

--- a/backend/services/apiFootballService.js
+++ b/backend/services/apiFootballService.js
@@ -1,0 +1,45 @@
+const axios = require('axios');
+require('dotenv').config();
+
+const API_HOST = 'api-football-v1.p.rapidapi.com';
+
+async function getMatchStats(player1, player2) {
+  const options = {
+    method: 'GET',
+    url: `https://${API_HOST}/v3/tennis/headToHead`,
+    params: { player1, player2 },
+    headers: {
+      'X-RapidAPI-Key': process.env.RAPIDAPI_KEY,
+      'X-RapidAPI-Host': API_HOST
+    }
+  };
+
+  try {
+    const { data } = await axios.request(options);
+    return data;
+  } catch (err) {
+    console.error('Error fetching tennis stats', err.message);
+    return null;
+  }
+}
+
+async function getUpcomingMatches() {
+  const options = {
+    method: 'GET',
+    url: `https://${API_HOST}/v3/tennis/fixtures`,
+    params: { next: 10 },
+    headers: {
+      'X-RapidAPI-Key': process.env.RAPIDAPI_KEY,
+      'X-RapidAPI-Host': API_HOST
+    }
+  };
+  try {
+    const { data } = await axios.request(options);
+    return data?.response || [];
+  } catch (err) {
+    console.error('Error fetching upcoming matches', err.message);
+    return [];
+  }
+}
+
+module.exports = { getMatchStats, getUpcomingMatches };

--- a/backend/services/openaiService.js
+++ b/backend/services/openaiService.js
@@ -1,0 +1,6 @@
+const OpenAI = require('openai');
+require('dotenv').config();
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+module.exports = { openai };

--- a/backend/services/theOddsService.js
+++ b/backend/services/theOddsService.js
@@ -1,0 +1,27 @@
+const axios = require('axios');
+require('dotenv').config();
+
+const BASE_URL = 'https://api.the-odds-api.com/v4/sports/tennis/events';
+
+async function getMatchOdds(player1, player2) {
+  const params = {
+    apiKey: process.env.THEODDS_API_KEY,
+    regions: 'us',
+    markets: 'h2h',
+    bookmakers: 'hardrock'
+  };
+
+  try {
+    const { data } = await axios.get(BASE_URL, { params });
+    // Filter events matching players (simplified)
+    const match = data.find(
+      (event) => event.home_team.includes(player1) && event.away_team.includes(player2)
+    );
+    return match || null;
+  } catch (err) {
+    console.error('Error fetching odds', err.message);
+    return null;
+  }
+}
+
+module.exports = { getMatchOdds };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "tennis-betting-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Tennis Betting AI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+
+function App() {
+  const [bets, setBets] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const fetchBets = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('http://localhost:5000/best-bets');
+      if (!res.ok) throw new Error('Request failed');
+      const data = await res.json();
+      setBets(data);
+    } catch (err) {
+      console.error('Failed to fetch best bets', err);
+      setError('Unable to load best bets. Please try again later.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>Tennis Betting AI</h1>
+      <button onClick={fetchBets} disabled={loading}>
+        {loading ? 'Loading...' : 'Show Best Bets'}
+      </button>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+
+      <ul>
+        {bets.map((bet, idx) => (
+          <li key={idx} style={{ marginTop: '1rem' }}>
+            <h3>{bet.players.player1} vs {bet.players.player2}</h3>
+            <p>{bet.summary}</p>
+            {bet.prediction && (
+              <>
+                <p>Win Probabilities: {bet.prediction.win_prob_player1}% / {bet.prediction.win_prob_player2}%</p>
+                <p>Value Bet: {bet.prediction.value_bet} ({bet.prediction.confidence_level})</p>
+              </>
+            )}
+            <p>{bet.explanation}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/implementationPlan.md
+++ b/implementationPlan.md
@@ -1,0 +1,33 @@
+1. **Backend Setup**
+   - Initialize Node.js backend in `/backend` with Express and CORS.
+   - Implement `openaiService.js` to configure the OpenAI client with `OPENAI_API_KEY` from `.env`.
+   - Create `apiFootballService.js` in `/backend/services` to fetch player statistics from API-Football's Tennis API via RapidAPI. Expose a `getMatchStats(player1, player2)` function that returns recent form, surface win rate, and head-to-head data.
+   - Create `theOddsService.js` in `/backend/services` to pull betting odds from TheOddsAPI (prioritizing Hard Rock when available). Provide a `getMatchOdds(player1, player2)` function that returns sportsbook odds and implied probabilities.
+   - Create three agent modules in `/backend/agents`:
+     - `matchAnalyst.js` to summarize matchup data using OpenAI.
+     - `predictionAgent.js` to calculate win probabilities and value bet recommendation.
+     - `explainerAgent.js` to generate a short explanation of the betting advice.
+
+2. **API Route**
+   - In `/backend/routes/predict.js` set up a POST handler to receive player names, match context, and odds.
+   - Use `apiFootballService.js` to fetch player stats automatically when the client only supplies names. Merge these stats with any manually provided data.
+   - Retrieve betting odds with `theOddsService.js` and calculate implied probabilities to compare against the LLM prediction.
+   - Sequentially call the three agents with the formatted stats and odds, then return `summary`, `prediction`, and `explanation` as JSON.
+   - Add a new `/best-bets` route that retrieves upcoming matches from the stats API, runs predictions for each, and returns the bets with the highest expected value.
+   - Wire the routes in `app.js` and start the server on port 5000.
+
+3. **Frontend Setup**
+   - Create a React app inside `/frontend` using `create-react-app`.
+   - Build a simple page with a **Show Best Bets** button instead of manual player selection.
+   - When clicked, call a new `/best-bets` endpoint that returns the top value bets for the next day.
+   - Display each bet's summary, win probabilities, recommended wager, and explanation.
+
+4. **Environment & Running**
+   - Add `.env` containing keys for `OPENAI_API_KEY`, `RAPIDAPI_KEY` (for API-Football), and `THEODDS_API_KEY`.
+   - Install backend dependencies: `npm install express cors dotenv openai`.
+   - Run the backend with `node app.js` and the frontend with `npm start` inside `/frontend`.
+
+5. **MVP Goals**
+   - Focus on on-demand predictions with no database. API calls to API-Football and TheOddsAPI occur only at runtime, keeping the app stateless.
+   - Ensure error handling for failed API calls and invalid form input.
+   - Later enhancements could include persistent storage or authentication if desired.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "dev": "pnpm -r --parallel --filter='./packages/*' run dev",
     "release": "tsx scripts/release.ts",
     "ci-publish": "tsx scripts/publishCI.ts",
-    "ci-docs": "pnpm build && pnpm docs-build"
+    "ci-docs": "pnpm build && pnpm docs-build",
+    "start-tennis-app": "concurrently \"pnpm --filter ./backend start\" \"npm start --prefix frontend\""
   },
   "devDependencies": {
     "@eslint/js": "^9.28.0",
@@ -68,6 +69,7 @@
     "prettier": "3.5.3",
     "rollup": "^4.40.0",
     "simple-git-hooks": "^2.13.0",
+    "concurrently": "^8.2.2",
     "tsx": "^4.19.4",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.33.1",


### PR DESCRIPTION
## Summary
- add `start` script for the backend
- allow running both servers via `start-tennis-app`
- document the new command in `TENNIS_APP_README.md`

## Testing
- `pnpm run test-unit` *(fails: command not found: vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6843840ec4d88325993d7bd508278781